### PR TITLE
The 'large' time estimate was wrong

### DIFF
--- a/cache.manifest
+++ b/cache.manifest
@@ -1,5 +1,5 @@
 CACHE MANIFEST
-# version 7
+# version 8
 js/crypto-sha256.js
 js/wordlist.js
 js/random.js

--- a/index.html
+++ b/index.html
@@ -165,11 +165,11 @@
                 var entropy = sentence.entropy.toFixed(1)
                   , possibles = Math.pow(2, sentence.entropy - 1) // on average, only half the possibilities will be needed.  so -1 exponent
                   , small_guesses_per_year = 1000 * 3600*24*365
-                  , large_guesses_per_year = 100000000 * 3600*24*365;
+                  , large_guesses_per_hour = 1e11 * 3600;
 
                 $('#generate .entropy').html(entropy + " bits of entropy.<br />" + 
                   (possibles / small_guesses_per_year).toFixed(1) + " years to guess at 1000 guesses/second.<a href='#online'>[1]</a><br />" +
-                  (possibles / large_guesses_per_year).toFixed(1) + " years to guess at 100 billion guesses/second.<a href='#offline'>[2]</a>");
+                  (possibles / large_guesses_per_hour).toFixed(1) + " hours to guess at 100 billion guesses/second.<a href='#offline'>[2]</a>");
               };
 
           $('#generate_button').click(generate_password);


### PR DESCRIPTION
It was calculating the time at 1e8 (100 million) guesses/second, not 1e11 (100 billion). This fixes the calculation to really use 1e11, and changes the units from hours to years to make the numbers readable.
